### PR TITLE
Add ability to send empty email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.0.1
+------
+
+* Fix `template_name` by making it compulsory in the function signature.
+
 v2.0.0
 ------
 

--- a/incuna_mail.py
+++ b/incuna_mail.py
@@ -8,9 +8,8 @@ def listify(obj):
     return [obj] if isinstance(obj, six.string_types) else obj
 
 
-def send(sender=None, to=None, cc=None, bcc=None, subject='mail',
-         attachments=(), template_name=None, html_template_name=None,
-         context=None, headers=None):
+def send(template_name, sender=None, to=None, cc=None, bcc=None, subject='mail',
+         attachments=(), html_template_name=None, context=None, headers=None):
     """
     Render and send an email.  `template_name` is a plaintext template.
 
@@ -40,10 +39,10 @@ def send(sender=None, to=None, cc=None, bcc=None, subject='mail',
         'headers': headers or {},
     }
 
-    text_content = render_to_string(template_name or (), context)
+    text_content = render_to_string(template_name, context)
     email_kwargs['body'] = text_content
 
-    if not html_template_name:
+    if html_template_name is None:
         msg = EmailMessage(**email_kwargs)
     else:
         msg = EmailMultiAlternatives(**email_kwargs)

--- a/tests/test_incuna_mail.py
+++ b/tests/test_incuna_mail.py
@@ -6,7 +6,7 @@ import incuna_mail
 
 
 class TestIncunaMail(TestCase):
-    def send_and_assert_email(self, html_template_name=()):
+    def send_and_assert_email(self, html_template_name=None):
         """Runs send() on proper input and checks the result."""
         kwargs = {
             'sender': ['email@example.com'],
@@ -49,6 +49,11 @@ class TestIncunaMail(TestCase):
         email = self.send_and_assert_email('dummy_html_template.html')
         self.assertEqual(email.body, u'hello!\n')
         self.assertEqual(email.alternatives[0], (u'<p>hi!</p>\n', 'text/html'))
+
+    def test_do_not_send_empty_email(self):
+        """Regression test to assert empty email can't be send."""
+        with self.assertRaises(TypeError):
+            incuna_mail.send()
 
 
 class TestListify(TestCase):


### PR DESCRIPTION
At the moment it's impossible to send an email with an empty body. The `send` method uses `render_to_string` and accepts a template path name. Leaving it to `None` raises a `TemplateDoesNotExist`. `send` should check is `template_name` is `None` and don't call `render_to_string` if it's the case.