### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Incuna Mail  [![Build Status](https://travis-ci.org/incuna/incuna-mail.svg?branch=i5-add-tests)](https://travis-ci.org/incuna/incuna-mail)  [![Coverage Status](https://img.shields.io/coveralls/incuna/incuna-mail.svg)](https://coveralls.io/r/incuna/incuna-mail) [![Wheel Status](https://pypip.in/wheel/incuna-mail/badge.png)](https://pypi.python.org/pypi/incuna-mail/) [![Latest Version](https://pypip.in/version/incuna-mail/badge.png)](https://pypi.python.org/pypi/incuna-mail/)
+# Incuna Mail  [![Build Status](https://travis-ci.org/incuna/incuna-mail.svg?branch=i5-add-tests)](https://travis-ci.org/incuna/incuna-mail)  [![Coverage Status](https://img.shields.io/coveralls/incuna/incuna-mail.svg)](https://coveralls.io/r/incuna/incuna-mail) [![Wheel Status](https://img.shields.io/pypi/wheel/incuna-mail.svg)](https://pypi.python.org/pypi/incuna-mail/) [![Latest Version](https://img.shields.io/pypi/v/incuna-mail.svg)](https://pypi.python.org/pypi/incuna-mail/)
 
 Pythonic utility for sending template based emails with Django.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20incuna-mail))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `incuna-mail`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.